### PR TITLE
osc.phrase_output_format not applied to /phrase/{deck}/next

### DIFF
--- a/src/outputmodules/osc.rs
+++ b/src/outputmodules/osc.rs
@@ -316,7 +316,7 @@ impl OutputModule for Osc {
 
     fn next_phrase_changed(&mut self, phrase: &str, deck: usize) {
         if self.message_toggles.phrase{
-            self.send_string(&format!("/{deck}/phrase/next"), phrase);
+            self.output_phrase(&format!("/{deck}/phrase/next"), phrase);
         }
     }
 


### PR DESCRIPTION
**Describe the bug**
/phrase/{deck}/next is always sent as a string and ignores `osc.phrase_output_format`. `/phrase/master/next` works as expected.
<img width="738" height="537" alt="image" src="https://github.com/user-attachments/assets/fec98e7c-e63f-419c-bf71-5468be28482b" />


**Expected behaviour**
`/phrase/{deck}/next` should follow `osc.phrase_output_format` (string/int/float), the same as the master route.

**Steps To Reproduce**
1. Enable OSC.
2. Set `osc.msg.phrase_master = true` and `osc.msg.phrase = true`.
3. Set `osc.phrase_output_format = int` (or `float`).
4. Trigger a next-phrase change and check OSC argument types for `/phrase/master/next` vs `/phrase/{deck}/next`.

**Other details**
- Software version: 1.1.0  
- Detailed Rekordbox version: 6.8.5